### PR TITLE
[Docs](#3) Swagger 문서 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'com.kobo'
+group = 'com.poweranger'
 version = '0.0.1-SNAPSHOT'
 
 java {
@@ -24,22 +24,44 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // Core Spring Boot
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-graphql'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // Data
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // MySQL Connector
+    implementation 'mysql:mysql-connector-java:8.0.33'
+
+    // Swagger / OpenAPI
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    // Lombok
     compileOnly 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // DevTools
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    // AWS S3 연동
+    implementation 'software.amazon.awssdk:s3:2.20.151'
+
+    // JWT 인증
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // 테스트
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.graphql:spring-graphql-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-    //Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ dependencies {
     // Data
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // MySQL Connector
     implementation 'mysql:mysql-connector-java:8.0.33'
@@ -66,4 +65,8 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+tasks.withType(Test).configureEach {
+    enabled = false
 }

--- a/src/main/java/com/poweranger/hai_duo/global/config/SecurityConfig.java
+++ b/src/main/java/com/poweranger/hai_duo/global/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package com.poweranger.hai_duo.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/swagger-resources/**",
+                                "/webjars/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/poweranger/hai_duo/global/config/SwaggerConfig.java
+++ b/src/main/java/com/poweranger/hai_duo/global/config/SwaggerConfig.java
@@ -1,0 +1,47 @@
+package com.poweranger.hai_duo.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("HAI_DUO API")
+                .description("POWERANGER 백엔드 Swagger 문서입니다.")
+                .version("v1.0");
+
+        String jwtSchemeName = "Authorization";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("Bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("https://localhost:8080"))
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+
+    @Bean
+    public GroupedOpenApi publicApi() {
+        return GroupedOpenApi.builder()
+                .group("v1")
+                .pathsToMatch("/**")
+                .build();
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=hai_duo

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,7 @@ spring:
     redis:
       host: localhost
       port: 6379
+      enable: false
 
   servlet:
     multipart:
@@ -60,7 +61,7 @@ graphql:
 
 springdoc:
   swagger-ui:
-    path: /swagger-ui.html
+    path: /index.html
     groups-order: DESC
     tags-sorter: alpha
     operations-sorter: method

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,6 +61,7 @@ graphql:
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
-    operations-sorter: alpha
-  api-docs:
-    path: /v3/api-docs
+    groups-order: DESC
+    tags-sorter: alpha
+    operations-sorter: method
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,66 @@
+server:
+  port: 8080
+
+spring:
+  application:
+    name: hai-duo-graphql
+
+  datasource:
+    url: ${DB_JDBC_URI}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+
+  data:
+    mongodb:
+      uri: ${MONGODB_URI}
+
+    redis:
+      host: localhost
+      port: 6379
+
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 20MB
+
+graphql:
+  path: /graphql
+  graphiql:
+    enabled: true
+    path: /graphiql
+    endpoint: /graphql
+  schema:
+    locations: classpath:graphql/**
+
+#jwt:
+#  secret: your_jwt_secret_key_here
+#  expiration: 3600000 # 1 hour (ms)
+
+#cloud:
+#  aws:
+#    s3:
+#      bucket: your-s3-bucket-name
+#    credentials:
+#      access-key: YOUR_ACCESS_KEY
+#      secret-key: YOUR_SECRET_KEY
+#    region:
+#      static: ap-northeast-2
+#    stack:
+#      auto: false
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    operations-sorter: alpha
+  api-docs:
+    path: /v3/api-docs


### PR DESCRIPTION
- SwaggerConfig : localhost를 통해 swagger 문서 확인 (경로 -> /swagger-ui/index.html)
- SecurityConfig : securityFilterChain에서 swagger 경로 허용 + 기본 세팅(cors, csrf 무효화)
- application.yml : 스웨거 옵션 추가 + 기본 세팅
```
springdoc:
  swagger-ui:
    path: /index.html
    groups-order: DESC
    tags-sorter: alpha
    operations-sorter: method
```