### PR TITLE
Feat/#5 임시회원 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,6 @@ dependencies {
     // Swagger / OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
-    // graphl
-    implementation 'com.graphql-java-kickstart:graphql-java-tools:13.0.2'
-
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     // Swagger / OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+    // graphl
+    implementation 'com.graphql-java-kickstart:graphql-java-tools:13.0.2'
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/poweranger/hai_duo/global/config/SecurityConfig.java
+++ b/src/main/java/com/poweranger/hai_duo/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.poweranger.hai_duo.global.config;
 
+import com.poweranger.hai_duo.global.config.security.TempUserAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -7,10 +9,14 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+@RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private final TempUserAuthenticationFilter tempUserAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -27,10 +33,12 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/swagger-resources/**",
                                 "/webjars/**",
-                                "/graphql"
+                                "/graphql",
+                                "/api/users/temp"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(tempUserAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 }

--- a/src/main/java/com/poweranger/hai_duo/global/config/SecurityConfig.java
+++ b/src/main/java/com/poweranger/hai_duo/global/config/SecurityConfig.java
@@ -26,7 +26,8 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
                                 "/swagger-resources/**",
-                                "/webjars/**"
+                                "/webjars/**",
+                                "/graphql"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/poweranger/hai_duo/global/config/security/TempUserAuthenticationFilter.java
+++ b/src/main/java/com/poweranger/hai_duo/global/config/security/TempUserAuthenticationFilter.java
@@ -1,0 +1,40 @@
+package com.poweranger.hai_duo.global.config.security;
+
+import com.poweranger.hai_duo.user.domain.repository.UserRepository;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class TempUserAuthenticationFilter implements Filter {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        String authHeader = httpRequest.getHeader("Authorization");
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String tempUserId = authHeader.substring(7);
+
+            userRepository.findByTempUserToken(tempUserId).ifPresent(user -> {
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList());
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                request.setAttribute("tempUser", user);
+            });
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/poweranger/hai_duo/global/response/code/ErrorStatus.java
+++ b/src/main/java/com/poweranger/hai_duo/global/response/code/ErrorStatus.java
@@ -11,7 +11,10 @@ public enum ErrorStatus implements BaseCode {
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // 멤버 관련
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4001", "사용자가 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/poweranger/hai_duo/user/api/controller/UserController.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/controller/UserController.java
@@ -1,7 +1,7 @@
 package com.poweranger.hai_duo.user.api.controller;
 
-import com.poweranger.hai_duo.user.api.resolver.UserMutationResolver;
 import com.poweranger.hai_duo.user.api.dto.UserDto;
+import com.poweranger.hai_duo.user.application.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -10,15 +10,10 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class UserController {
 
-    private final UserMutationResolver userMutationResolver;
+    private final UserService userService;
 
     @PostMapping("/temp")
     public UserDto createTempUser() {
-        return userMutationResolver.createTempUser();
-    }
-
-    @GetMapping("/{id}")
-    public UserDto getUserById(@PathVariable Long id) {
-        return userMutationResolver.getUserById(id);
+        return userService.createTempUser();
     }
 }

--- a/src/main/java/com/poweranger/hai_duo/user/api/controller/UserController.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/controller/UserController.java
@@ -1,0 +1,24 @@
+package com.poweranger.hai_duo.user.api.controller;
+
+import com.poweranger.hai_duo.user.application.service.UserService;
+import com.poweranger.hai_duo.user.api.dto.UserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/temp")
+    public UserDto createTempUser() {
+        return userService.createTempUser();
+    }
+
+    @GetMapping("/{id}")
+    public UserDto getUserById(@PathVariable Long id) {
+        return userService.getUserById(id);
+    }
+}

--- a/src/main/java/com/poweranger/hai_duo/user/api/controller/UserController.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.poweranger.hai_duo.user.api.controller;
 
-import com.poweranger.hai_duo.user.application.service.UserService;
+import com.poweranger.hai_duo.user.api.resolver.UserMutationResolver;
 import com.poweranger.hai_duo.user.api.dto.UserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -10,15 +10,15 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class UserController {
 
-    private final UserService userService;
+    private final UserMutationResolver userMutationResolver;
 
     @PostMapping("/temp")
     public UserDto createTempUser() {
-        return userService.createTempUser();
+        return userMutationResolver.createTempUser();
     }
 
     @GetMapping("/{id}")
     public UserDto getUserById(@PathVariable Long id) {
-        return userService.getUserById(id);
+        return userMutationResolver.getUserById(id);
     }
 }

--- a/src/main/java/com/poweranger/hai_duo/user/api/dto/UserDto.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/dto/UserDto.java
@@ -5,22 +5,22 @@ import com.poweranger.hai_duo.user.domain.entity.User;
 
 public record UserDto(
         Long userId,
-        String tempUserId,
+        String tempUserToken,
         int exp,
+        int goldAmount,
         Long levelId,
         Long characterId,
-        int goldAmount,
         LocalDateTime createdAt,
         LocalDateTime lastAccessedAt
 ) {
     public static UserDto from(User user) {
         return new UserDto(
                 user.getUserId(),
-                user.getTempUserId(),
+                user.getTempUserToken(),
                 user.getExp(),
+                user.getGoldAmount(),
                 user.getLevelId(),
                 user.getCharacterId(),
-                user.getGoldAmount(),
                 user.getCreatedAt(),
                 user.getLastAccessedAt()
         );

--- a/src/main/java/com/poweranger/hai_duo/user/api/dto/UserDto.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/dto/UserDto.java
@@ -1,0 +1,28 @@
+package com.poweranger.hai_duo.user.api.dto;
+
+import java.time.LocalDateTime;
+import com.poweranger.hai_duo.user.domain.entity.User;
+
+public record UserDto(
+        Long userId,
+        String tempUserId,
+        int exp,
+        Long levelId,
+        Long characterId,
+        int goldAmount,
+        LocalDateTime createdAt,
+        LocalDateTime lastAccessedAt
+) {
+    public static UserDto from(User user) {
+        return new UserDto(
+                user.getUserId(),
+                user.getTempUserId(),
+                user.getExp(),
+                user.getLevelId(),
+                user.getCharacterId(),
+                user.getGoldAmount(),
+                user.getCreatedAt(),
+                user.getLastAccessedAt()
+        );
+    }
+}

--- a/src/main/java/com/poweranger/hai_duo/user/api/resolver/UserMutationResolver.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/resolver/UserMutationResolver.java
@@ -15,4 +15,8 @@ public class UserMutationResolver implements GraphQLMutationResolver {
     public UserDto createTempUser() {
         return userService.createTempUser();
     }
+
+    public UserDto getUserById(Long id) {
+        return userService.getUserById(id);
+    }
 }

--- a/src/main/java/com/poweranger/hai_duo/user/api/resolver/UserMutationResolver.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/resolver/UserMutationResolver.java
@@ -2,18 +2,18 @@ package com.poweranger.hai_duo.user.api.resolver;
 
 import com.poweranger.hai_duo.user.application.service.UserService;
 import com.poweranger.hai_duo.user.api.dto.UserDto;
-import graphql.kickstart.tools.GraphQLMutationResolver;
 import lombok.RequiredArgsConstructor;
-import org.springframework.graphql.data.method.annotation.Argument;
-import org.springframework.stereotype.Component;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.stereotype.Controller;
 
-@Component
+@Controller
 @RequiredArgsConstructor
-public class UserMutationResolver implements GraphQLMutationResolver {
+public class UserMutationResolver {
 
     private final UserService userService;
 
-    public UserDto getUserById(@Argument("userId") Long id) {
-        return userService.getUserById(id);
+    @MutationMapping
+    public UserDto createTempUser() {
+        return userService.createTempUser();
     }
 }

--- a/src/main/java/com/poweranger/hai_duo/user/api/resolver/UserMutationResolver.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/resolver/UserMutationResolver.java
@@ -12,10 +12,6 @@ public class UserMutationResolver implements GraphQLMutationResolver {
 
     private final UserService userService;
 
-    public UserDto createTempUser() {
-        return userService.createTempUser();
-    }
-
     public UserDto getUserById(Long id) {
         return userService.getUserById(id);
     }

--- a/src/main/java/com/poweranger/hai_duo/user/api/resolver/UserMutationResolver.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/resolver/UserMutationResolver.java
@@ -1,0 +1,18 @@
+package com.poweranger.hai_duo.user.api.resolver;
+
+import com.poweranger.hai_duo.user.application.service.UserService;
+import com.poweranger.hai_duo.user.api.dto.UserDto;
+import graphql.kickstart.tools.GraphQLMutationResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserMutationResolver implements GraphQLMutationResolver {
+
+    private final UserService userService;
+
+    public UserDto createTempUser() {
+        return userService.createTempUser();
+    }
+}

--- a/src/main/java/com/poweranger/hai_duo/user/api/resolver/UserMutationResolver.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/resolver/UserMutationResolver.java
@@ -4,6 +4,7 @@ import com.poweranger.hai_duo.user.application.service.UserService;
 import com.poweranger.hai_duo.user.api.dto.UserDto;
 import graphql.kickstart.tools.GraphQLMutationResolver;
 import lombok.RequiredArgsConstructor;
+import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,7 +13,7 @@ public class UserMutationResolver implements GraphQLMutationResolver {
 
     private final UserService userService;
 
-    public UserDto getUserById(Long id) {
+    public UserDto getUserById(@Argument("userId") Long id) {
         return userService.getUserById(id);
     }
 }

--- a/src/main/java/com/poweranger/hai_duo/user/api/resolver/UserQueryResolver.java
+++ b/src/main/java/com/poweranger/hai_duo/user/api/resolver/UserQueryResolver.java
@@ -1,0 +1,20 @@
+package com.poweranger.hai_duo.user.api.resolver;
+
+import com.poweranger.hai_duo.user.api.dto.UserDto;
+import com.poweranger.hai_duo.user.application.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class UserQueryResolver {
+
+    private final UserService userService;
+
+    @QueryMapping
+    public UserDto getUserById(@Argument Long userId) {
+        return userService.getUserById(userId);
+    }
+}

--- a/src/main/java/com/poweranger/hai_duo/user/application/service/UserService.java
+++ b/src/main/java/com/poweranger/hai_duo/user/application/service/UserService.java
@@ -1,5 +1,7 @@
 package com.poweranger.hai_duo.user.application.service;
 
+import com.poweranger.hai_duo.global.exception.GeneralException;
+import com.poweranger.hai_duo.global.response.code.ErrorStatus;
 import com.poweranger.hai_duo.user.api.dto.UserDto;
 import com.poweranger.hai_duo.user.domain.repository.UserRepository;
 import com.poweranger.hai_duo.user.domain.entity.User;
@@ -16,14 +18,21 @@ public class UserService {
 
     public UserDto createTempUser() {
         User user = User.builder()
-                .tempUserId(UUID.randomUUID().toString())
+                .tempUserToken(UUID.randomUUID().toString())
                 .exp(0)
                 .goldAmount(0)
                 .levelId(1L)
                 .characterId(1L)
+                .createdAt(LocalDateTime.now())
                 .lastAccessedAt(LocalDateTime.now())
                 .build();
 
         return UserDto.from(userRepository.save(user));
+    }
+
+    public UserDto getUserById(Long id) {
+        return userRepository.findById(id)
+                .map(UserDto::from)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/poweranger/hai_duo/user/application/service/UserService.java
+++ b/src/main/java/com/poweranger/hai_duo/user/application/service/UserService.java
@@ -1,0 +1,29 @@
+package com.poweranger.hai_duo.user.application.service;
+
+import com.poweranger.hai_duo.user.api.dto.UserDto;
+import com.poweranger.hai_duo.user.domain.repository.UserRepository;
+import com.poweranger.hai_duo.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserDto createTempUser() {
+        User user = User.builder()
+                .tempUserId(UUID.randomUUID().toString())
+                .exp(0)
+                .goldAmount(0)
+                .levelId(1L)
+                .characterId(1L)
+                .lastAccessedAt(LocalDateTime.now())
+                .build();
+
+        return UserDto.from(userRepository.save(user));
+    }
+}

--- a/src/main/java/com/poweranger/hai_duo/user/domain/entity/User.java
+++ b/src/main/java/com/poweranger/hai_duo/user/domain/entity/User.java
@@ -19,7 +19,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
 
-    private String tempUserId;
+    private String tempUserToken;
     private int exp;
     private int goldAmount;
     private Long levelId;

--- a/src/main/java/com/poweranger/hai_duo/user/domain/entity/User.java
+++ b/src/main/java/com/poweranger/hai_duo/user/domain/entity/User.java
@@ -1,0 +1,33 @@
+package com.poweranger.hai_duo.user.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    private String tempUserId;
+    private int exp;
+    private int goldAmount;
+    private Long levelId;
+    private Long characterId;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(nullable = false)
+    private LocalDateTime lastAccessedAt = LocalDateTime.now();
+}

--- a/src/main/java/com/poweranger/hai_duo/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/poweranger/hai_duo/user/domain/repository/UserRepository.java
@@ -3,7 +3,9 @@ package com.poweranger.hai_duo.user.domain.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import com.poweranger.hai_duo.user.domain.entity.User;
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByTempUserToken(String tempUserId);
 }

--- a/src/main/java/com/poweranger/hai_duo/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/poweranger/hai_duo/user/domain/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.poweranger.hai_duo.user.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import com.poweranger.hai_duo.user.domain.entity.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   application:
-    name: hai-duo-graphql
+    name: hai-duo
 
   datasource:
     url: ${DB_JDBC_URI}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,7 @@ graphql:
     path: /graphiql
     endpoint: /graphql
   schema:
-    locations: classpath:graphql/**
+    locations: classpath:graphql/
 
 #jwt:
 #  secret: your_jwt_secret_key_here

--- a/src/main/resources/graphql/user.graphqls
+++ b/src/main/resources/graphql/user.graphqls
@@ -8,7 +8,7 @@ type Query {
 
 type UserDto {
   userId: ID!
-  tempUserId: String!
+  tempUserToken: String!
   exp: Int!
   levelId: ID!
   characterId: ID!

--- a/src/main/resources/graphql/user.graphqls
+++ b/src/main/resources/graphql/user.graphqls
@@ -1,0 +1,18 @@
+type Mutation {
+  createTempUser: UserDto
+}
+
+type Query {
+  getUserById(userId: ID!): UserDto
+}
+
+type UserDto {
+  userId: ID!
+  tempUserId: String!
+  exp: Int!
+  levelId: ID!
+  characterId: ID!
+  goldAmount: Int!
+  createdAt: String!
+  lastAccessedAt: String!
+}


### PR DESCRIPTION
# 📄 개요 

이번 PR(#5)에서는 임시회원 생성 및 조회 기능을 GraphQL과 REST API로 나누어 역할을 분리하고, Spring 공식 방식으로 GraphQL 어노테이션을 통일하였습니다. 기존 임시회원 생성 로직을 리팩토링하며, API 접근 방식을 명확히 구분했습니다.

# ✅ 주요 변경 사항
- [feat] UserMutationResolver 추가
- createTempUser를 GraphQL mutation으로 처리하는 resolver 구현
- [refactor] REST 생성 / GraphQL 조회 방식으로 역할 분리
     - 생성은 /api/users/temp REST 방식
     - 조회는 getUserById(userId: ID!) GraphQL Query로 처리
- [fix] @Argument 어노테이션 누락으로 인해 전달되지 않던 userId 오류 수정
- [config] spring.application.name을 hai-duo로 지정
- [refactor] 기존 kickstart 방식 → Spring GraphQL 어노테이션(@QueryMapping 등)으로 통일

# 🧪 테스트 방식
- Postman으로 임시회원 생성 REST API (POST /api/users/temp) 요청
- GraphQL IDE (Altair/Postman)로 다음 Query 수행:
```
query {
  getUserById(userId: 1) {
    userId
    tempUserToken
    exp
    goldAmount
    levelId
    characterId
    createdAt
    lastAccessedAt
  }
}
```